### PR TITLE
Add Catppuccin themed styling for Waybar

### DIFF
--- a/style.css
+++ b/style.css
@@ -1,174 +1,111 @@
-/* === База: шрифт/размер === */
+@import "./themes/catppuccin-mocha.css";
+
+/* Base typography */
 * {
-  font-family: "JetBrainsMono Nerd Font", monospace;
-  font-size: 14px;
-  border: none;
-  min-height: 10px;
+  font-family: "0xProto Nerd Font";
+  font-weight: bold;
+  font-size: 16px;
+  color: @main-fg;
 }
 
-/* === Парящая шапка с лёгкой дымкой === */
+/* Layout */
 window#waybar {
-  background: rgba(34, 36, 54, 0.45);     /* дымка */
-  border: 1px solid rgba(255, 255, 255, 0.06);
-  box-shadow: 0 8px 24px rgba(0,0,0,0.35);
+  background-color: @shadow;
+}
+window#waybar > box {
+  margin: 4px;
+  background-color: @main-bg;
 }
 
-/* Скрытие (если используешь hidden mode) */
-window#waybar.hidden { opacity: 0.2; }
-
-/* === Общие правила для видимых модулей === */
-/* Твоя структура: #custom-menu | #workspaces | (справа) #tray + #clock #cpu #memory #disk #battery + #custom-power */
-#custom-menu,
-#workspaces,
-#tray,
-#clock,
-#cpu,
-#memory,
-#disk,
-#battery,
-#custom-power {
-  color: #161320;
-  margin-top: 6px;
-  margin-bottom: 6px;
-  padding-left: 10px;
-  padding-right: 10px;
-  transition: none;
+/* Tooltips */
+tooltip {
+  border: 2px solid @main-br;
   border-radius: 10px;
+  background-color: @main-bg;
+}
+tooltip label {
+  margin: 2px 4px;
+  font-weight: normal;
 }
 
-/* Равномерные горизонтальные интервалы между правыми модулями */
-#tray > .tray-item,
-#clock,
-#cpu,
-#memory,
-#disk,
-#battery {
-  margin-left: 6px;
-  margin-right: 6px;
-}
-
-/* Немного «воздуха» слева/справа у крайних элементов */
-#custom-menu { margin-left: 8px; }
-#custom-power { margin-right: 8px; }
-
-/* === Конкретные стили === */
-
-/* Левое меню (иконка/кнопка) */
+/* Menu button */
 #custom-menu {
+  background-color: @accent;
+  color: @main-bg;
+  padding: 0 14px;
+  margin: 6px 8px;
+  border-radius: 10px;
   font-size: 18px;
-  color: #89B4FA;
-  background: #161320;         /* тёмная «плашка» */
-  padding-left: 14px;
-  padding-right: 14px;
 }
 #custom-menu:hover {
-  background: #1b1728;            /* чуть светлее #161320 */
-  box-shadow: 0 0 0 1px rgba(255,255,255,0.06) inset;
+  background-color: @hover-bg;
+  color: @hover-fg;
 }
 
-/* Центр: рабочие столы Hyprland */
+/* Workspaces */
 #workspaces {
-  background: rgba(0, 0, 0, 0.45);
+  background-color: @workspaces;
   border-radius: 10px;
   margin: 6px 5px;
   padding: 0 6px;
 }
 #workspaces button {
   all: unset;
-  color: #B5E8E0;
-  background: transparent;
+  color: @accent;
   padding: 4px 6px;
-  transition: color .2s ease, text-shadow .2s ease, transform .2s ease;
   border-radius: 8px;
 }
-#workspaces button.occupied { color: #A6E3A1; }
 #workspaces button.active {
-  color: #89B4FA;
-  text-shadow: 0 0 4px #ABE9B3;
+  color: @hover-fg;
 }
-#workspaces button:hover { color: #89B4FA; }
-#workspaces button.urgent {
-  color: #0b1220;
-  background: #f38ba8;
+#workspaces button:hover {
+  background-color: @hover-bg;
 }
 
-/* Правые модули — «цветные бейджи» как в примере */
-#clock   { background: #ABE9B3; } /* мягкий зелёный */
-#cpu     { background: #96CDFB; }
-#memory  { background: #DDB6F2; }
-#disk    { background: #F5C2E7; }
-#battery { background: #F8BD96; } /* тёплый оранжеватый */
-
-/* Hover-эффект для правых модулей */
-#clock:hover,
-#cpu:hover,
-#memory:hover,
-#disk:hover,
-#battery:hover {
-  box-shadow: 0 0 0 2px rgba(0,0,0,0.12) inset;
-  opacity: 0.98;  /* мягкий эффект; если вдруг ругнётся — просто удали строку */
-}
-/* Состояния батареи (если Waybar помечает .warning/.critical) */
-#battery.warning {
-  background: #F8BD96;
-  color: #161320;
-}
-#battery.critical {
-  background: #BF616A;
-  color: #B5E8E0;
-  animation: blink 1s step-end infinite;
-}
-
-/* Кнопка питания справа (если используешь #custom-power) */
-#custom-power {
-  background: #1f1b2e;
-  color: #eaeaea;
-  padding-left: 12px;
-  padding-right: 12px;
-}
-#custom-power:hover { color: #89B4FA; }
-
-/* === Анимация (опционально) === */
-@keyframes blink {
-  to {
-    background-color: #BF616A;
-    color: #B5E8E0;
-  }
-}
-
-/* === Tray — «пилюли» на каждую иконку === */
+/* Tray */
 #tray {
-  background: transparent;
+  background-color: transparent;
   margin: 6px 5px;
   padding: 0 4px;
 }
-
-/* у большинства сборок иконки — кнопки без класса */
 #tray > *,
 #tray button {
-  background: rgba(34, 36, 54, 0.50);
+  background-color: @tray;
   border-radius: 8px;
   padding: 4px;
   margin: 0 4px;
 }
 
-#tray > *:hover,
-#tray button:hover {
-  box-shadow: 0 0 0 2px rgba(0,0,0,0.12) inset;
+/* Resource modules */
+#clock,
+#cpu,
+#memory,
+#disk,
+#battery {
+  margin: 6px;
+  padding: 0 10px;
+  border-radius: 10px;
+  color: @main-bg;
 }
+#clock { background-color: @time; }
+#cpu { background-color: @cpu; }
+#memory { background-color: @memory; }
+#disk { background-color: @disk; }
+#battery { background-color: @battery; }
 
-/* состояния, если Waybar их навешивает */
-#tray > .passive,
-#tray button.passive {
-  background: rgba(34, 36, 54, 0.35);
-}
-#tray > .needs-attention,
-#tray button.needs-attention {
-  animation: blink 0.8s step-end infinite;
-}
+/* Battery states */
+.warning { color: @warning; }
+.critical { color: @critical; }
+.charging { color: @charging; }
 
-/* на всякий — убираем лишние отступы у самих картинок */
-#tray image {
-  margin: 0;
-  padding: 0;
+/* Power button */
+#custom-power {
+  background-color: @main-bg;
+  color: @accent;
+  padding: 0 12px;
+  margin: 6px 8px 6px 6px;
+  border-radius: 10px;
+}
+#custom-power:hover {
+  background-color: @hover-bg;
 }

--- a/themes/catppuccin-frappe.css
+++ b/themes/catppuccin-frappe.css
@@ -1,0 +1,50 @@
+/* Catppuccin Frappe */
+@define-color rosewater #f2d5cf;
+@define-color flamingo #eebebe;
+@define-color pink #f4b8e4;
+@define-color mauve #ca9ee6;
+@define-color red #e78284;
+@define-color maroon #ea999c;
+@define-color peach #ef9f76;
+@define-color yellow #e5c890;
+@define-color green #a6d189;
+@define-color teal #81c8be;
+@define-color sky #99d1db;
+@define-color sapphire #85c1dc;
+@define-color blue #8caaee;
+@define-color lavender #babbf1;
+@define-color text #c6d0f5;
+@define-color subtext1 #b5bfe2;
+@define-color subtext0 #a5adce;
+@define-color overlay2 #949cbb;
+@define-color overlay1 #838ba7;
+@define-color overlay0 #737994;
+@define-color surface2 #626880;
+@define-color surface1 #51576d;
+@define-color surface0 #414559;
+@define-color base #303446;
+@define-color mantle #292c3c;
+@define-color crust #232634;
+
+/* main colors */
+@define-color main-br @subtext0;
+@define-color main-bg @crust;
+@define-color main-fg @text;
+@define-color accent @lavender;
+@define-color hover-bg @base;
+@define-color hover-fg alpha(@text, 0.75);
+@define-color shadow shade(@crust, 0.5);
+
+/* module colors */
+@define-color workspaces @mantle;
+@define-color tray @mantle;
+@define-color cpu @surface0;
+@define-color memory @base;
+@define-color disk @surface1;
+@define-color time @surface0;
+@define-color battery @surface0;
+
+/* state colors */
+@define-color warning @yellow;
+@define-color critical @red;
+@define-color charging @green;

--- a/themes/catppuccin-latte.css
+++ b/themes/catppuccin-latte.css
@@ -1,0 +1,50 @@
+/* Catppuccin Latte */
+@define-color rosewater #dc8a78;
+@define-color flamingo #dd7878;
+@define-color pink #ea76cb;
+@define-color mauve #8839ef;
+@define-color red #d20f39;
+@define-color maroon #e64553;
+@define-color peach #fe640b;
+@define-color yellow #df8e1d;
+@define-color green #40a02b;
+@define-color teal #179299;
+@define-color sky #04a5e5;
+@define-color sapphire #209fb5;
+@define-color blue #1e66f5;
+@define-color lavender #7287fd;
+@define-color text #4c4f69;
+@define-color subtext1 #5c5f77;
+@define-color subtext0 #6c6f85;
+@define-color overlay2 #7c7f93;
+@define-color overlay1 #8c8fa1;
+@define-color overlay0 #9ca0b0;
+@define-color surface2 #acb0be;
+@define-color surface1 #bcc0cc;
+@define-color surface0 #ccd0da;
+@define-color base #eff1f5;
+@define-color mantle #e6e9ef;
+@define-color crust #dce0e8;
+
+/* main colors */
+@define-color main-br @subtext0;
+@define-color main-bg @crust;
+@define-color main-fg @text;
+@define-color accent @lavender;
+@define-color hover-bg @base;
+@define-color hover-fg alpha(@text, 0.75);
+@define-color shadow shade(@crust, 0.5);
+
+/* module colors */
+@define-color workspaces @mantle;
+@define-color tray @mantle;
+@define-color cpu @surface0;
+@define-color memory @base;
+@define-color disk @surface1;
+@define-color time @surface0;
+@define-color battery @surface0;
+
+/* state colors */
+@define-color warning @yellow;
+@define-color critical @red;
+@define-color charging @green;

--- a/themes/catppuccin-mocha.css
+++ b/themes/catppuccin-mocha.css
@@ -1,0 +1,50 @@
+/* Catppuccin Mocha */
+@define-color rosewater #f5e0dc;
+@define-color flamingo #f2cdcd;
+@define-color pink #f5c2e7;
+@define-color mauve #cba6f7;
+@define-color red #f38ba8;
+@define-color maroon #eba0ac;
+@define-color peach #fab387;
+@define-color yellow #f9e2af;
+@define-color green #a6e3a1;
+@define-color teal #94e2d5;
+@define-color sky #89dceb;
+@define-color sapphire #74c7ec;
+@define-color blue #89b4fa;
+@define-color lavender #b4befe;
+@define-color text #cdd6f4;
+@define-color subtext1 #bac2de;
+@define-color subtext0 #a6adc8;
+@define-color overlay2 #9399b2;
+@define-color overlay1 #7f849c;
+@define-color overlay0 #6c7086;
+@define-color surface2 #585b70;
+@define-color surface1 #45475a;
+@define-color surface0 #313244;
+@define-color base #1e1e2e;
+@define-color mantle #181825;
+@define-color crust #11111b;
+
+/* main colors */
+@define-color main-br @subtext0;
+@define-color main-bg @crust;
+@define-color main-fg @text;
+@define-color accent @lavender;
+@define-color hover-bg @base;
+@define-color hover-fg alpha(@text, 0.75);
+@define-color shadow shade(@crust, 0.5);
+
+/* module colors */
+@define-color workspaces @mantle;
+@define-color tray @mantle;
+@define-color cpu @surface0;
+@define-color memory @base;
+@define-color disk @surface1;
+@define-color time @surface0;
+@define-color battery @surface0;
+
+/* state colors */
+@define-color warning @yellow;
+@define-color critical @red;
+@define-color charging @green;


### PR DESCRIPTION
## Summary
- theme-aware style.css importing Catppuccin palette
- mocha, frappe and latte theme files

## Testing
- `waybar --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b7556d1640832b88ba57c03bc44309